### PR TITLE
Fixing WAN Matching Logic for Failover

### DIFF
--- a/wpa_supplicant/wtf-wpa.sh
+++ b/wpa_supplicant/wtf-wpa.sh
@@ -176,7 +176,7 @@ parse-wan-int () {
 # Checks ubios-udapi-server.state to determine the WAN port
 	if [ -f /data/udapi-config/ubios-udapi-server/ubios-udapi-server.state ]; then
 		# Parses udapi-net-cfg.json and for first interface in wanFailover yaml object
-		udapi_wan_int=$(jq -r '.services.wanFailover.wanInterfaces.[0].interface' /data/udapi-config/udapi-net-cfg.json | awk -F"." '{print $1}')
+		udapi_wan_int=$(jq -r '.services.wanFailover.wanInterfaces | min_by(.metric) | .interface' /data/udapi-config/udapi-net-cfg.json | awk -F"." '{print $1}')
 		output IY "WAN Int" "${udapi_wan_int}" && log I "WAN Interface: ${udapi_wan_int}"
 	else
 		output C "WAN Int" "Could not determine WAN interface from udapi-net-cfg - EXITING"; log E "Could not determine WAN interface from udapi-net-cfg - EXITING"


### PR DESCRIPTION
In my setup with a U5GMax as my failover, the primary WAN wasn't actually first in the list anymore. The way to find the actual WAN is to sort the list by `.metric` and pick the lowest. I changed the jq command to do this. This is tested and working on my UDM Pro.